### PR TITLE
Crawl files which do have a canonical tag pointing to itself

### DIFF
--- a/lib/LuceneSearch/Model/Parser.php
+++ b/lib/LuceneSearch/Model/Parser.php
@@ -561,13 +561,15 @@ class Parser
         $filter = new \Zend_Filter_Word_UnderscoreToDash();
         $language = strtolower($filter->filter($language));
 
-        //page has canonical link: do not track!
+        //page has canonical link: do not track if this is not the canonical document
         $hasCanonicalLink = $crawler->filterXpath('//link[@rel="canonical"]')->count() > 0;
 
         if ($hasCanonicalLink === TRUE) {
-            $this->log('[parser] skip indexing [ ' . $link . ' ] because it has canonical links');
+            if($link != $crawler->filterXpath('//link[@rel="canonical"]')->attr('href')){
+                $this->log('[parser] skip indexing [ ' . $link . ' ] because it has canonical link '.$crawler->filterXpath('//link[@rel="canonical"]')->attr('href').'');
 
-            return FALSE;
+                return FALSE;
+            }
         }
 
         //page has no follow: do not track!


### PR DESCRIPTION
It's a good practice to include canonical meta tags even for the site itself: http://www.thesempost.com/using-rel-canonical-on-all-pages-for-duplicate-content-protection/
The plugin should parse these sites too.