### PR TITLE
FIX: Enabled the usage of floats due to faultily generated configuration

### DIFF
--- a/lib/LuceneSearch/Crawler/Filter/PostFetch/MaxContentSizeFilter.php
+++ b/lib/LuceneSearch/Crawler/Filter/PostFetch/MaxContentSizeFilter.php
@@ -31,7 +31,7 @@ class MaxContentSizeFilter implements PostFetchFilterInterface
         $size = $resource->getResponse()->getBody()->getSize();
         $sizeMb = $size / 1024 / 1024;
 
-        if ($this->maxFileSize === 0 || $sizeMb <= $this->maxFileSize) {
+        if ($this->maxFileSize == 0 || $sizeMb <= $this->maxFileSize) {
             return FALSE;
         }
 


### PR DESCRIPTION
If you configure Lucene Search via the Pimcore UI the value for max filesize will be set as float,
e.g. 0.0 instead of 0 .