### PR TITLE
Add possibility to define custom templates to display results page

### DIFF
--- a/docs/90_Frontend_Implementation.md
+++ b/docs/90_Frontend_Implementation.md
@@ -12,6 +12,17 @@ This guide will help you to implement a search page into your website in seconds
 ```
 
 This will load the result template from `@LuceneSearch/Resources/views/List/result.html.twig`.
+If you want to use your own custom template to display the search results, pass an additional parameter:
+
+```twig
+{{ render(controller('lucene_search.controller.frontend.list:getResultAction', {
+    templateDir: 'Search'
+})) }}
+```
+
+**Attention: If you choose to make use of custom templates, make sure you provide the following files**
+- [result.html.twig](src/LuceneSearchBundle/Resources/views/List/result.html.twig)
+- [error.html.twig](src/LuceneSearchBundle/Resources/views/List/error.html.twig)
 
 ### Ajax AutoComplete
 Use this snippet to allow ajax driven auto-complete search. you may want to use this [plugin](https://github.com/devbridge/jQuery-Autocomplete) to do the job.

--- a/src/LuceneSearchBundle/Controller/ListController.php
+++ b/src/LuceneSearchBundle/Controller/ListController.php
@@ -20,7 +20,7 @@ class ListController extends FrontendController
         $this->highlighterHelper = $highlighterHelper;
     }
 
-    public function getResultAction()
+    public function getResultAction($templateDir = '@LuceneSearch/List')
     {
         $requestQuery = $this->requestStack->getMasterRequest()->query;
 
@@ -156,7 +156,7 @@ class ListController extends FrontendController
             $viewName = 'error';
         }
 
-        $content = $this->templating->render('@LuceneSearch/List/' . $viewName . '.html.twig', $viewParams);
+        $content = $this->templating->render($templateDir . DIRECTORY_SEPARATOR . $viewName . '.html.twig', $viewParams);
 
         $response = new Response($content);
 


### PR DESCRIPTION
With this PR the possibility to define a custom template is reintroduced similar to what LuceneSearch 1.x.x already provided.

Happy to hear your feedback on this!