### PR TITLE
Add full html to HtmlParserEvent

### DIFF
--- a/src/LuceneSearchBundle/Event/HtmlParserEvent.php
+++ b/src/LuceneSearchBundle/Event/HtmlParserEvent.php
@@ -14,7 +14,12 @@ class HtmlParserEvent extends Event
     /**
      * @var string
      */
-    private $html;
+    private $parsedHtml;
+
+    /**
+     * @var string
+     */
+    private $fullHtml;
 
     /**
      * @var array
@@ -25,13 +30,15 @@ class HtmlParserEvent extends Event
      * HtmlParserEvent constructor.
      *
      * @param \Zend_Search_Lucene_Document $document
-     * @param                              $html
+     * @param                              $parsedHtml
+     * @param                              $fullHtml
      * @param                              $params
      */
-    public function __construct(\Zend_Search_Lucene_Document $document, $html, $params)
+    public function __construct(\Zend_Search_Lucene_Document $document, $parsedHtml, $fullHtml, $params)
     {
         $this->document = $document;
-        $this->html = $html;
+        $this->parsedHtml = $parsedHtml;
+        $this->fullHtml = $fullHtml;
         $this->params = $params;
     }
 
@@ -54,11 +61,29 @@ class HtmlParserEvent extends Event
     }
 
     /**
+     * @deprecated Use getParsedHtml() instead.
+     *
      * @return string
      */
     public function getHtml()
     {
+        return $this->getParsedHtml();
+    }
+
+    /**
+     * @return string
+     */
+    public function getParsedHtml()
+    {
         return $this->html;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFullHtml()
+    {
+        return $this->fullHtml;
     }
 
     /**

--- a/src/LuceneSearchBundle/Task/Parser/ParserTask.php
+++ b/src/LuceneSearchBundle/Task/Parser/ParserTask.php
@@ -182,6 +182,7 @@ class ParserTask extends AbstractTask
         $stream = $resource->getResponse()->getBody();
         $stream->rewind();
         $html = $stream->getContents();
+        $originalHtml = $html;
 
         $contentTypeInfo = $resource->getResponse()->getHeaderLine('Content-Type');
         $contentLanguage = $resource->getResponse()->getHeaderLine('Content-Language');
@@ -329,7 +330,7 @@ class ParserTask extends AbstractTask
             'object_id'    => $objectId
         ];
 
-        $this->addHtmlToIndex($html, $params);
+        $this->addHtmlToIndex($html, $originalHtml, $params);
 
         $this->log(sprintf('added html to indexer stack: %s', $uri));
 
@@ -466,7 +467,7 @@ class ParserTask extends AbstractTask
      *
      * @return void
      */
-    protected function addHtmlToIndex($html, $params)
+    protected function addHtmlToIndex($html, $originalHtml, $params)
     {
         $defaults = [
             'title'        => null,
@@ -564,7 +565,7 @@ class ParserTask extends AbstractTask
             // add internal availability flag
             $doc->addField(\Zend_Search_Lucene_Field::keyword('internalAvailability', 'available'));
 
-            $parserEvent = new HtmlParserEvent($doc, $html, $params);
+            $parserEvent = new HtmlParserEvent($doc, $html, $originalHtml, $params);
             $this->eventDispatcher->dispatch(
                 LuceneSearchEvents::LUCENE_SEARCH_PARSER_HTML_DOCUMENT,
                 $parserEvent

--- a/src/LuceneSearchBundle/Task/Parser/ParserTask.php
+++ b/src/LuceneSearchBundle/Task/Parser/ParserTask.php
@@ -2,12 +2,12 @@
 
 namespace LuceneSearchBundle\Task\Parser;
 
+use LuceneSearchBundle\Configuration\Configuration;
 use LuceneSearchBundle\Event\AssetResourceRestrictionEvent;
 use LuceneSearchBundle\Event\HtmlParserEvent;
 use LuceneSearchBundle\Event\PdfParserEvent;
 use LuceneSearchBundle\LuceneSearchEvents;
 use LuceneSearchBundle\Task\AbstractTask;
-use LuceneSearchBundle\Configuration\Configuration;
 use Pimcore\Document\Adapter\Ghostscript;
 use Pimcore\Model\Asset;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -462,8 +462,9 @@ class ParserTask extends AbstractTask
     /**
      * adds a HTML page to lucene index and mysql table for search result summaries
      *
-     * @param  string $html
-     * @param  array  $params
+     * @param string $html
+     * @param string $originalHtml
+     * @param array  $params
      *
      * @return void
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes

and mark getHtml deprecated in favour of getParsedHtml to be more clear.

This makes it possible to parse whatever you want and add it to the index.