### PR TITLE
Update ParserTask.php

### DIFF
--- a/src/LuceneSearchBundle/Task/Parser/ParserTask.php
+++ b/src/LuceneSearchBundle/Task/Parser/ParserTask.php
@@ -519,7 +519,7 @@ class ParserTask extends AbstractTask
 
             $doc->addField(\Zend_Search_Lucene_Field::keyword('charset', $params['encoding']));
             $doc->addField(\Zend_Search_Lucene_Field::keyword('lang', $params['language']));
-            $doc->addField(\Zend_Search_Lucene_Field::keyword('url', $params['uri']));
+            $doc->addField(\Zend_Search_Lucene_Field::keyword('url', $params['uri'], $params['encoding']));
             $doc->addField(\Zend_Search_Lucene_Field::keyword('host', $params['host']));
 
             $doc->addField(\Zend_Search_Lucene_Field::text('title', $params['title'], $params['encoding']));


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

I found the url parameter was not being written to the index so when href="{{ searchResult.url }} was called in result.html.twig the value was always blank meaning it was not possible to follow search results.  Adding the encoding fixed the issue.
